### PR TITLE
fix: added enviroment

### DIFF
--- a/.github/workflows/job-deploy.yaml
+++ b/.github/workflows/job-deploy.yaml
@@ -51,3 +51,6 @@ jobs:
 
       - name: Show Output
         run: echo "Cloud Run Job ${{ env.JOB_NAME }} deployed/updated successfully in region ${{ env.REGION }}"
+
+    environment:
+      name: Production


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/job-deploy.yaml` file. The change adds an `environment` section to specify the deployment environment as "Production".

* [`.github/workflows/job-deploy.yaml`](diffhunk://#diff-587fbbbec23d032249f022c6bcf6415483ab5ec97f17cd3bedbde9c537b38e0aR54-R56): Added an `environment` section to specify the deployment environment as "Production".