### PR TITLE
fix: address of docker image

### DIFF
--- a/.github/workflows/job-deploy.yaml
+++ b/.github/workflows/job-deploy.yaml
@@ -1,5 +1,6 @@
 name: Build and Deploy to Cloud Run Job
 
+
 on:
   push:
     branches:
@@ -9,6 +10,7 @@ on:
 env:
   PROJECT_ID: pypi-package-analysis-437421
   GAR_LOCATION: us-east4
+  REPO_NAME: pypi-package-analysis-ar
   JOB_NAME: pypi-package-analysis-job
   REGION: us-east1
 
@@ -36,15 +38,15 @@ jobs:
 
       - name: Build Container
         run: |-
-          docker build -t ${{ env.GAR_LOCATION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.JOB_NAME }}/${{ env.JOB_NAME }}:${{ github.sha }} ./
+          docker build -t ${{ env.GAR_LOCATION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.REPO_NAME }}/application-job:${{ github.sha }} ./
 
       - name: Push Container
-        run: docker push ${{ env.GAR_LOCATION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.JOB_NAME }}/${{ env.JOB_NAME }}:${{ github.sha }}
+        run: docker push ${{ env.GAR_LOCATION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.REPO_NAME }}/application-job:${{ github.sha }}
 
       - name: Deploy or Update Cloud Run Job
         run: |-
           gcloud run jobs update ${{ env.JOB_NAME }} \
-              --image=${{ env.GAR_LOCATION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.JOB_NAME }}/${{ env.JOB_NAME }}:${{ github.sha }} \
+              --image=${{ env.GAR_LOCATION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.REPO_NAME }}/application-job:${{ github.sha }} \
               --region=${{ env.REGION }} \
               --task-timeout=600s \
               --max-retries=3


### PR DESCRIPTION
This pull request includes updates to the `.github/workflows/job-deploy.yaml` file to modify the build and deployment process for a Cloud Run job. The most important changes include adding a new environment variable and updating the Docker image references.

Environment configuration:

* Added `REPO_NAME` environment variable to specify the repository name for the Docker image.

Docker image references:

* Updated the `docker build` command to use the new `REPO_NAME` environment variable in the image tag.
* Updated the `docker push` command to use the new `REPO_NAME` environment variable in the image tag.
* Updated the `gcloud run jobs update` command to use the new `REPO_NAME` environment variable in the image reference.