### PR TITLE
fix: GCLOUD region

### DIFF
--- a/.github/workflows/job-deploy.yaml
+++ b/.github/workflows/job-deploy.yaml
@@ -12,7 +12,7 @@ env:
   GAR_LOCATION: us-east4
   REPO_NAME: pypi-package-analysis-ar
   JOB_NAME: pypi-package-analysis-job
-  REGION: us-east1
+  REGION: us-east4
 
 jobs:
   deploy:


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/job-deploy.yaml` file. The change updates the `REGION` environment variable to `us-east4` to match the `GAR_LOCATION`.

* [`.github/workflows/job-deploy.yaml`](diffhunk://#diff-587fbbbec23d032249f022c6bcf6415483ab5ec97f17cd3bedbde9c537b38e0aL15-R15): Updated `REGION` from `us-east1` to `us-east4`.