### PR TITLE
feature: remove text files from CI/CD

### DIFF
--- a/.github/workflows/job-deploy.yaml
+++ b/.github/workflows/job-deploy.yaml
@@ -1,10 +1,18 @@
 name: Build and Deploy to Cloud Run Job
 
 
+
 on:
   push:
     branches:
       - main
+    paths-ignore:
+      - 'README.md'
+      - '*.md'
+      - '*.txt'
+      - 'LICENSE'
+      - .gitattributes
+      - .gitignore
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
This pull request includes a change to the `.github/workflows/job-deploy.yaml` file to improve the efficiency of the deployment workflow. The most important change is the addition of a `paths-ignore` section to prevent unnecessary deployments when certain files are modified.

Workflow improvements:

* [`.github/workflows/job-deploy.yaml`](diffhunk://#diff-587fbbbec23d032249f022c6bcf6415483ab5ec97f17cd3bedbde9c537b38e0aR4-R15): Added `paths-ignore` to prevent the deployment workflow from running when changes are made to non-essential files such as `README.md`, `LICENSE`, and other markdown or text files.