### PR TITLE
fix: offset on BigQuery

### DIFF
--- a/src/domain/use_cases/send_metrics_use_case.py
+++ b/src/domain/use_cases/send_metrics_use_case.py
@@ -25,10 +25,9 @@ class SendPypiStatsUseCase:
             INSTALLER_NAME,
             PYTHON_VERSION
             FROM {os.getenv('PROJECT_ID')}.STG.PYPI_PROJ_DOWNLOADS
-            WHERE DTTM >= DATETIME_SUB(CURRENT_DATETIME, INTERVAL 120 DAY)
+            WHERE DTTM >= DATETIME_SUB(CURRENT_DATETIME, INTERVAL 7 DAY)
             AND TRUE QUALIFY (ROW_NUMBER() OVER(PARTITION BY DTTM, COUNTRY_CODE, PROJECT, PACKAGE_VERSION, INSTALLER_NAME, PYTHON_VERSION ORDER BY DTTM ASC)) = 1
             AND NOT PUSHED
-            limit 5
             """
         df = self.dw_service.query_to_dataframe(query=query)
         return df


### PR DESCRIPTION
This pull request includes a change to the `get_stats` method in the `send_metrics_use_case.py` file to update the date range for the query. The most important change is:

* [`src/domain/use_cases/send_metrics_use_case.py`](diffhunk://#diff-5ff2ffa0cb5a842f038e104e130af75e7c2824080ffbd623857ea64555ad8d6bL28-L31): Modified the date range in the query from 120 days to 7 days to ensure more recent data is retrieved.